### PR TITLE
Remove NODE_BINARY export from .xcode.env.local

### DIFF
--- a/react-native/ios/.xcode.env.local
+++ b/react-native/ios/.xcode.env.local
@@ -1,1 +1,1 @@
-export NODE_BINARY=/Users/cchitu/.nvm/versions/node/v22.3.0/bin/node
+


### PR DESCRIPTION
This local env file seems to have been pushed by accident. It prevents the ios react native app from building on other machines